### PR TITLE
Add product api tests 

### DIFF
--- a/api-testing/controller.ts
+++ b/api-testing/controller.ts
@@ -1,8 +1,57 @@
 import axios from "axios";
+import jsonData from "../api-data.json";
 
 export class ApiControllers {
   async getUserById(userId: string | number) {
-    const r = await axios.get(`https://dummyjson.com/users/${userId}`);
+    const r = await axios.get(`${jsonData.baseUrl}/users/${userId}`);
     expect(r.status).toBe(200);
+    return r;
+  }
+
+  async getCurrentUser(token: string) {
+    return axios.get(`${jsonData.baseUrl}/user/me`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+  }
+
+  async updateUser(
+    userId: string | number,
+    data: { firstName?: string; lastName?: string; phone?: string },
+  ) {
+    return axios.put(`${jsonData.baseUrl}/users/${userId}`, data);
+  }
+
+  async getProductById(productId: string | number) {
+    return axios.get(`${jsonData.baseUrl}/products/${productId}`);
+  }
+
+  async getAllProducts() {
+    return axios.get(`${jsonData.baseUrl}/products`);
+  }
+
+  async searchProducts(query: string) {
+    return axios.get(`${jsonData.baseUrl}/products/search`, {
+      params: { q: query },
+    });
+  }
+
+  async getProductsByCategory(categorySlug: string) {
+    return axios.get(`${jsonData.baseUrl}/products/category/${categorySlug}`);
+  }
+
+  async getProductCategories() {
+    return axios.get(`${jsonData.baseUrl}/products/categories`);
+  }
+
+  async addProduct(data: Record<string, unknown>) {
+    return axios.post(`${jsonData.baseUrl}/products/add`, data);
+  }
+
+  async updateProduct(productId: string | number, data: Record<string, unknown>) {
+    return axios.put(`${jsonData.baseUrl}/products/${productId}`, data);
+  }
+
+  async deleteProduct(productId: string | number) {
+    return axios.delete(`${jsonData.baseUrl}/products/${productId}`);
   }
 }

--- a/api-testing/login.test.ts
+++ b/api-testing/login.test.ts
@@ -43,7 +43,8 @@ describe("authorization", () => {
         },
       },
     );
-    typedJsonData.token = auth_token_response.data.token;
+    expect(auth_token_response.status).toEqual(200);
+    typedJsonData.token = auth_token_response.data.accessToken;
     fs.writeJSONSync("api-data.json", typedJsonData);
   });
 });

--- a/api-testing/products.test.ts
+++ b/api-testing/products.test.ts
@@ -1,0 +1,76 @@
+import { ApiControllers } from "./controller";
+
+describe("tests for products", () => {
+  const controllers = new ApiControllers();
+
+  test("get product by id", async () => {
+    const response = await controllers.getProductById(1);
+    expect(response.status).toBe(200);
+    expect(response.data.id).toBe(1);
+    expect(response.data.title).toEqual(expect.any(String));
+    expect(response.data.category).toEqual(expect.any(String));
+    expect(response.data.price).toBeGreaterThan(0);
+  });
+
+  test("get all products", async () => {
+    const response = await controllers.getAllProducts();
+    expect(response.status).toBe(200);
+    expect(Array.isArray(response.data.products)).toBe(true);
+    expect(response.data.products.length).toBeGreaterThan(0);
+    expect(response.data.total).toBeGreaterThanOrEqual(response.data.products.length);
+  });
+
+  test("search products", async () => {
+    const query = "phone";
+    const response = await controllers.searchProducts(query);
+    expect(response.status).toBe(200);
+    expect(response.data.products.length).toBeGreaterThan(0);
+    for (const product of response.data.products) {
+      const haystack = `${product.title} ${product.description} ${product.category} ${product.brand}`.toLowerCase();
+      expect(haystack).toContain(query);
+    }
+  });
+
+  test("get products by category", async () => {
+    const category = "beauty";
+    const response = await controllers.getProductsByCategory(category);
+    expect(response.status).toBe(200);
+    expect(response.data.products.length).toBeGreaterThan(0);
+    for (const product of response.data.products) {
+      expect(product.category).toBe(category);
+    }
+  });
+
+  test("get product categories", async () => {
+    const response = await controllers.getProductCategories();
+    expect(response.status).toBe(200);
+    expect(Array.isArray(response.data)).toBe(true);
+    expect(response.data[0]).toHaveProperty("slug");
+    expect(response.data[0]).toHaveProperty("name");
+    expect(response.data[0]).toHaveProperty("url");
+  });
+
+  test("add product", async () => {
+    const newProduct = { title: "Test Product", category: "test-category" };
+    const response = await controllers.addProduct(newProduct);
+    expect(response.status).toBe(201);
+    expect(response.data.title).toBe(newProduct.title);
+    expect(response.data.id).toEqual(expect.any(Number));
+  });
+
+  test("update product", async () => {
+    const updatedTitle = "Updated Product Title";
+    const response = await controllers.updateProduct(1, { title: updatedTitle });
+    expect(response.status).toBe(200);
+    expect(response.data.id).toBe(1);
+    expect(response.data.title).toBe(updatedTitle);
+  });
+
+  test("delete product", async () => {
+    const response = await controllers.deleteProduct(1);
+    expect(response.status).toBe(200);
+    expect(response.data.id).toBe(1);
+    expect(response.data.isDeleted).toBe(true);
+    expect(response.data).toHaveProperty("deletedOn");
+  });
+});

--- a/api-testing/user.test.ts
+++ b/api-testing/user.test.ts
@@ -1,59 +1,44 @@
-import axios from "axios";
 import jsonData from "../api-data.json";
-import { fakerEN } from "@faker-js/faker";
 import { ApiControllers } from "./controller";
 
-const fUserName = fakerEN.person.firstName();
-const fLastName = fakerEN.person.lastName();
-const fPhoneN = fakerEN.phone.number();
+const randomString = (prefix: string) =>
+  `${prefix}${Math.random().toString(36).slice(2, 8)}`;
+
+const fUserName = randomString("First");
+const fLastName = randomString("Last");
+const fPhoneN = `+1555${Math.floor(1000000 + Math.random() * 8999999)}`;
 
 describe("tests for users", () => {
   const controllers = new ApiControllers();
-  const apiClient = axios.create({
-    baseURL: `${jsonData.baseUrl}`,
-  });
-
-  apiClient.interceptors.request.use(function (config) {
-    config.headers.Authorization = `Bearer ${jsonData.token}`;
-    console.log(`Request URL: ${config.baseURL}${config.url}`);
-    return config;
-  });
 
   test("get current user", async () => {
-    await apiClient.get(`/user/me`).then(function (response) {
-      console.log(response.data);
-      console.log(response.status);
-      console.log(response.statusText);
+    const response = await controllers.getCurrentUser(jsonData.token as string);
+    expect(response.status).toBe(200);
+    expect(response.data.id).toEqual(expect.any(Number));
+    expect(response.data.username).toEqual(expect.any(String));
+    expect(response.data.email).toEqual(expect.any(String));
+  });
+
+  test("get current user with invalid token", async () => {
+    await expect(controllers.getCurrentUser("invalid-token")).rejects.toMatchObject({
+      response: { status: 401 },
     });
   });
 
-  test("get current user with try/catch", async () => {
-    try {
-      await axios.get(`${jsonData.baseUrl}/user/me`).catch((err) => {
-        if (err.response.status == 404) {
-          throw new Error("Opa 404 errora");
-        }
-        throw err;
-      });
-    } catch (err) {
-      console.error(err);
-    }
-  });
-
-  test.skip("get current user with expect", async () => {
-    const reponseT = await axios.get(`${jsonData.baseUrl}/user/me`);
-    expect(reponseT.status).toBe(200);
-  });
-
   test("PUT user data", async () => {
-    await axios.put(`${jsonData.baseUrl}/users/4`, {
+    const response = await controllers.updateUser(4, {
       firstName: fUserName,
       lastName: fLastName,
       phone: fPhoneN,
     });
+    expect(response.status).toBe(200);
+    expect(response.data.firstName).toBe(fUserName);
+    expect(response.data.lastName).toBe(fLastName);
+    expect(response.data.phone).toBe(fPhoneN);
   });
 
   test("user controller", async () => {
-    await controllers.getUserById("4");
+    const response = await controllers.getUserById("4");
+    expect(response.data.id).toBe(4);
   });
 });

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "pretest": "npx jest api-testing/login.test.ts",
-    "test": "npx jest api-testing/user*.test.ts",
+    "test": "npx jest api-testing/user.test.ts api-testing/products.test.ts",
     "posttest": "echo 'tests finsished'",
     "run-playwith-ui-tests": "ENV=test npx playwright test tests-examples/storage-state-usage.spec.ts --project=chromium-with-setup",
     "ui_tests_light": "npx playwright test tests-examples/2example.spec.ts --project chromium --config playwright.config.stage.ts",


### PR DESCRIPTION
Extends ApiControllers with product endpoints (get by id, search, by category, categories, add/update/delete) and adds field-level response assertions in a new products.test.ts. Refactors user.test.ts to route through ApiControllers with real expect() checks instead of console logging, and drops the dead try/catch and test.skip cases.

Also fixes login.test.ts writing an undefined token: dummyjson's login response field is `accessToken`, not `token`, so every downstream "authenticated" request was silently running unauthenticated.